### PR TITLE
Order queryset by `priority`

### DIFF
--- a/views.py
+++ b/views.py
@@ -56,7 +56,7 @@ def return_viewset(class_name):
         def get_queryset(self):
             Model = swapper.load_model('faculty_biodata', class_name)
             faculty_member = get_role(self.request.person, 'FacultyMember')
-            return Model.objects.filter(faculty_member=faculty_member)
+            return Model.objects.filter(faculty_member=faculty_member).order_by('priority')
 
         def create(self, request, *args, **kwargs):
             """


### PR DESCRIPTION
Currently, Drag and Drop is not functioning as expected. Upon updating the order, respective priority of objects did update, but the objects weren't ordered by priority on the respective endpoints, so upon reloading, the actual priority order was not maintained in Frontend.

This PR solves this, by ordering the objects on the basis of `priority`.