### PR TITLE
Define the attribute `is_completed` directly in cms-omniport API

### DIFF
--- a/serializers.py
+++ b/serializers.py
@@ -39,9 +39,6 @@ def return_serializer(class_name):
             source='faculty_member.person.full_name'
         )
 
-        if hasattr(Model, 'has_already_ended'):
-            is_completed = serializers.SerializerMethodField()
-
         class Meta:
             """
             Meta class for Serializer
@@ -49,14 +46,6 @@ def return_serializer(class_name):
 
             model = Model
             fields = '__all__'
-
-        def get_is_completed(self, instance):
-            """
-            Returns if the duration of an instance has ended
-            :return: if the duration of an instance has ended
-            """
-
-            return instance.has_already_ended
 
     return Serializer
 


### PR DESCRIPTION
@nisarg73 please confirm if this doesn't break anything.