### PR TITLE
Close the handle availability check to anonymous callers

### DIFF
--- a/views.py
+++ b/views.py
@@ -23,6 +23,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
 
 from kernel.managers.get_role import get_role
 from omniport.settings.configuration.base import CONFIGURATION
@@ -237,20 +238,17 @@ class ProfileViewset(ModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=True, methods=['get'], permission_classes=[])
+    @action(detail=True, methods=['get'], permission_classes=[IsAuthenticated])
     def handle(self, request, pk=None):
         """
-        A view to check whether a handle is already taken
+        A view to check whether a handle is already taken, used only by the
+        profile form, so it is closed to anonymous callers
         """
-        try:
-            profile = models['Profile'].objects.get(handle=pk)
-            print(profile)
-            if profile is not None:
-                return Response("no")
-        except:
-            return Response("yes")
-        return Response("yes")
-        
+
+        taken = models['Profile'].objects.filter(handle=pk).exists()
+        return Response("no" if taken else "yes")
+
+
 viewset_dict["Profile"] = ProfileViewset
 
 


### PR DESCRIPTION
## Summary

`ProfileViewset.handle` is decorated
`@action(detail=True, methods=['get'], permission_classes=[])`. An explicit
empty list overrides `DEFAULT_PERMISSION_CLASSES`, so the project-wide default
added in omniport-backend#226 structurally cannot reach it.

The action returns only whether a handle is taken, so it is an existence
oracle rather than a personal data leak, but it has no reason to be open. Its
only callers are `checkHandle` and `handleErrors` in
`omniport-frontend-faculty-profile`'s profile form, both of which run for a
signed-in faculty member editing their own profile, and the app declares no
public face in its `config.json`. It now requires `IsAuthenticated`.

Two things in the body went with it: the `get` plus bare `except` pair
becomes an `exists()` query, which is what the `"yes"`/`"no"` return values
already mean and which no longer swallows unrelated errors into `"yes"`, and
a leftover debug `print` is removed.

## Test plan

No test suite in this repo, so both checks ran from a throwaway harness.

- Parsed `views.py` with `ast` at `HEAD` and on this branch, reporting the
  `handle` action's declared permission classes. Before:
  `permission_classes=[]`. After: `permission_classes=['IsAuthenticated']`.
- Booted Django 4.1 + DRF 3.14 with
  `DEFAULT_PERMISSION_CLASSES = ('rest_framework.permissions.IsAuthenticated',)`
  and an action in the new shape. Anonymous `GET` returns 403
  `not_authenticated`; the previous shape returned 200 with `"no"`/`"yes"`.
- Confirmed the `"yes"` means available and `"no"` means taken contract the
  frontend reads is unchanged by the `exists()` rewrite.
- `python3 -m py_compile views.py`.